### PR TITLE
Import types module

### DIFF
--- a/tap_hubspot/client.py
+++ b/tap_hubspot/client.py
@@ -2,6 +2,9 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional
 
+import types
+import copy
+
 import backoff
 import pytz
 import requests
@@ -263,7 +266,7 @@ class HubspotStream(RESTStream):
         for i in range(0, len(all_records), batch_size):
             result.append(list(all_records[i:i + batch_size]))
         return result
-        
+
 
     def get_all_url_params(self, url_params: Iterable[dict], context: Optional[dict], next_page_token: Optional[Any]):
 
@@ -292,19 +295,19 @@ class HubspotStream(RESTStream):
         )
 
         return request
-    
+
 
     def prepare_request(
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> requests.PreparedRequest:
-        
-        all_url_params = self.get_url_params(context, next_page_token) 
+
+        all_url_params = self.get_url_params(context, next_page_token)
 
         if isinstance(all_url_params, types.GeneratorType):
             for url_params in all_url_params:
                 request = self.get_all_url_params(url_params, context, next_page_token)
                 yield request
-        
+
         else:
             request = self.get_all_url_params(all_url_params, context, next_page_token)
             yield request


### PR DESCRIPTION


# What was the issue
When calling the tap via Meltano it raises a NameError for types module. Importing the module should fix the issue.

# How did we solve it
There are two modules used without being imported - types and copy. Importing the modules should fix the issue.

# Additional Notes / Warnings


# Fun fact (optional)
