### PR TITLE
Fix large logs (DOPS-106)

### DIFF
--- a/tap_hubspot/events_streams.py
+++ b/tap_hubspot/events_streams.py
@@ -49,6 +49,7 @@ class WebAnalyticsContactsStream(EventsStream):
     parent_stream_type = ContactsStream
     ignore_parent_replication_key = False
     replication_key = "occurredAt"
+    state_partitioning_keys=[]
 
     def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
@@ -64,6 +65,7 @@ class WebAnalyticsDealsStream(EventsStream):
     parent_stream_type = DealsStream
     ignore_parent_replication_key = False
     replication_key = "occurredAt"
+    state_partitioning_keys=[]
 
     def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)


### PR DESCRIPTION
[DOPS-106](https://dexthq.atlassian.net/browse/DOPS-106)

# What was the issue
Remove storing of state bookmarks for streams having Contacts as a parent stream. The Contacts stream has too  many items and this affects the length of the state kept in the logs.

# How did we solve it
Setting the state_partitioning_keys parameter to empty list solves the issue.


[DOPS-106]: https://dexthq.atlassian.net/browse/DOPS-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ